### PR TITLE
Add mermaid graph editor page

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,22 @@
+# Mermaid Graph Editor
 
+This simple app allows you to edit and render [Mermaid](https://mermaid-js.github.io/) diagrams directly in the browser. You can download the rendered graph as an SVG image and store frequently used snippets as templates using your browser's local storage.
+
+## Usage
+
+1. Open `index.html` in a browser.
+2. Enter your Mermaid code in the text area and press **Render** to view the diagram.
+3. Select **Download Image** to save the rendered diagram as `graph.svg`.
+4. Click **Save Template** to store the current Mermaid code under a name of your choice. Use **Load Template** to select a saved template.
+
+Templates are stored locally in your browser using `localStorage` and are not synced anywhere else.
+
+## Running a Local Server
+
+You can serve the page locally with Python:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000` in your browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mermaid Graph Editor</title>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        textarea { width: 100%; height: 200px; }
+        #graphContainer { border: 1px solid #ccc; padding: 10px; margin-top: 20px; }
+    </style>
+</head>
+<body>
+    <h1>Mermaid Graph Editor</h1>
+    <textarea id="code" placeholder="Enter mermaid code here"></textarea>
+    <div>
+        <button id="renderBtn">Render</button>
+        <button id="downloadBtn">Download Image</button>
+        <button id="saveTemplateBtn">Save Template</button>
+        <select id="templates"></select>
+        <button id="loadTemplateBtn">Load Template</button>
+    </div>
+    <div id="graphContainer"></div>
+    <script>
+        mermaid.initialize({startOnLoad:false});
+
+        function renderGraph() {
+            const code = document.getElementById('code').value;
+            const container = document.getElementById('graphContainer');
+            container.innerHTML = `<div class="mermaid">${code}</div>`;
+            mermaid.init(undefined, container);
+        }
+
+        document.getElementById('renderBtn').addEventListener('click', renderGraph);
+
+        // Template handling
+        function updateTemplateList() {
+            const select = document.getElementById('templates');
+            select.innerHTML = '';
+            const keys = Object.keys(localStorage).filter(k => k.startsWith('template_'));
+            keys.forEach(key => {
+                const option = document.createElement('option');
+                option.value = key;
+                option.textContent = key.replace('template_', '');
+                select.appendChild(option);
+            });
+        }
+
+        document.getElementById('saveTemplateBtn').addEventListener('click', () => {
+            const name = prompt('Template name?');
+            if (name) {
+                const code = document.getElementById('code').value;
+                localStorage.setItem('template_' + name, code);
+                updateTemplateList();
+            }
+        });
+
+        document.getElementById('loadTemplateBtn').addEventListener('click', () => {
+            const select = document.getElementById('templates');
+            const key = select.value;
+            if (key) {
+                const code = localStorage.getItem(key);
+                document.getElementById('code').value = code;
+                renderGraph();
+            }
+        });
+
+        updateTemplateList();
+
+        // Download image
+        document.getElementById('downloadBtn').addEventListener('click', () => {
+            const svg = document.querySelector('#graphContainer svg');
+            if (!svg) return;
+            const xml = new XMLSerializer().serializeToString(svg);
+            const blob = new Blob([xml], {type: 'image/svg+xml'});
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'graph.svg';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create `index.html` to edit, render, and download mermaid diagrams
- allow saving/loading diagrams as templates in localStorage
- update `Readme.md` with usage instructions

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_684aa406b0bc83278f1bfcae1c6438aa