### PR TITLE
Improve rendering reliability

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,1 +1,24 @@
+# Mermaid Graph Editor
 
+This simple app allows you to edit and render [Mermaid](https://mermaid-js.github.io/) diagrams directly in the browser. You can download the rendered graph as an SVG image and store frequently used snippets as templates using your browser's local storage. The interface is styled with basic CSS for a clean, modern look. Rendering now uses `mermaid.render` for better reliability when re-rendering after fixing errors.
+
+## Usage
+
+1. Open `index.html` in a browser.
+2. Enter your Mermaid code in the text area and press **Render** to view the diagram.
+3. Select **Download Image** to save the rendered diagram as `graph.svg`.
+4. Click **Save Template** to store the current Mermaid code under a name of your choice. Use **Load Template** to select a saved template.
+
+If your diagram contains syntax errors, an error message will appear below the controls.
+
+Templates are stored locally in your browser using `localStorage` and are not synced anywhere else.
+
+## Running a Local Server
+
+You can serve the page locally with Python:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then visit `http://localhost:8000` in your browser.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mermaid Graph Editor</title>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background: #f4f4f4;
+            margin: 0;
+            padding: 20px;
+        }
+        .container {
+            max-width: 960px;
+            margin: 0 auto;
+            background: #fff;
+            padding: 20px;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        }
+        textarea {
+            width: 100%;
+            height: 240px;
+            font-family: monospace;
+            margin-bottom: 10px;
+        }
+        .controls {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            margin-bottom: 10px;
+        }
+        #graphContainer {
+            border: 1px solid #ccc;
+            padding: 10px;
+            min-height: 120px;
+            overflow: auto;
+        }
+        #error {
+            color: #b30000;
+            margin-top: 10px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Mermaid Graph Editor</h1>
+    <textarea id="code" placeholder="Enter mermaid code here">graph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Do this]\n    B -->|No| D[Do that]</textarea>
+    <div class="controls">
+        <button id="renderBtn">Render</button>
+        <button id="downloadBtn">Download Image</button>
+        <button id="saveTemplateBtn">Save Template</button>
+        <select id="templates"></select>
+        <button id="loadTemplateBtn">Load Template</button>
+    </div>
+    <div id="error"></div>
+    <div id="graphContainer"></div>
+</div>
+    <script>
+        // Configure Mermaid without automatically parsing diagrams on page load
+        mermaid.initialize({ startOnLoad: false });
+
+        // Render the diagram from the textarea into the container
+        async function renderGraph() {
+            const code = document.getElementById('code').value;
+            const container = document.getElementById('graphContainer');
+            const errorBox = document.getElementById('error');
+            errorBox.textContent = '';
+            container.innerHTML = '';
+
+            try {
+                const { svg } = await mermaid.render('mermaidGraph', code);
+                container.innerHTML = svg;
+            } catch (err) {
+                errorBox.textContent = 'Mermaid error: ' + (err.str || err.message);
+            }
+        }
+
+        document.getElementById('renderBtn').addEventListener('click', renderGraph);
+
+        // Template handling
+        function updateTemplateList() {
+            const select = document.getElementById('templates');
+            select.innerHTML = '';
+            const keys = Object.keys(localStorage).filter(k => k.startsWith('template_'));
+            keys.forEach(key => {
+                const option = document.createElement('option');
+                option.value = key;
+                option.textContent = key.replace('template_', '');
+                select.appendChild(option);
+            });
+        }
+
+        document.getElementById('saveTemplateBtn').addEventListener('click', () => {
+            const name = prompt('Template name?');
+            if (name) {
+                const code = document.getElementById('code').value;
+                localStorage.setItem('template_' + name, code);
+                updateTemplateList();
+            }
+        });
+
+        document.getElementById('loadTemplateBtn').addEventListener('click', () => {
+            const select = document.getElementById('templates');
+            const key = select.value;
+            if (key) {
+                const code = localStorage.getItem(key);
+                document.getElementById('code').value = code;
+                renderGraph();
+            }
+        });
+
+        updateTemplateList();
+
+        // Download image
+        document.getElementById('downloadBtn').addEventListener('click', () => {
+            const svg = document.querySelector('#graphContainer svg');
+            if (!svg) return;
+            const xml = new XMLSerializer().serializeToString(svg);
+            const blob = new Blob([xml], {type: 'image/svg+xml'});
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'graph.svg';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- use `mermaid.render` for diagram rendering
- clarify readme about the new rendering method

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_684aa406b0bc83278f1bfcae1c6438aa