### PR TITLE
Add AI diagram generation via Ollama

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,3 +24,15 @@ python3 -m http.server 8000
 ```
 
 Then visit `http://localhost:8000` in your browser.
+
+## AI Generation with Ollama
+
+To create diagrams from natural language prompts, install [Ollama](https://github.com/jmorganca/ollama) and start its API server:
+
+```bash
+ollama serve
+```
+
+With the server running, use the **AI Generate** button in the editor. The text field labeled **Ollama API URL** lets you specify the API endpoint (default `http://localhost:11434`).
+The list of models is fetched automatically from the server and shown in a drop-down so you can pick which one to use for generation.
+Enter a prompt describing your diagram and the selected model will return Mermaid code that is placed in the editor automatically.

--- a/index.html
+++ b/index.html
@@ -84,6 +84,9 @@
         <button id="saveTemplateBtn">Save Template</button>
         <select id="templates"></select>
         <button id="loadTemplateBtn">Load Template</button>
+        <input id="ollamaUrl" type="text" value="http://localhost:11434" title="Ollama API URL" style="min-width:180px">
+        <select id="modelSelect"></select>
+        <button id="aiBtn">AI Generate</button>
     </div>
     <div id="error"></div>
     <div id="graphContainer"></div>
@@ -161,6 +164,58 @@
             document.body.removeChild(a);
             URL.revokeObjectURL(url);
         });
+
+        // Fetch models from Ollama and populate the dropdown
+        async function fetchModels() {
+            const url = document.getElementById('ollamaUrl').value;
+            const select = document.getElementById('modelSelect');
+            select.innerHTML = '';
+            try {
+                const resp = await fetch(url + '/api/tags');
+                const data = await resp.json();
+                const models = data.models || [];
+                models.forEach(m => {
+                    const opt = document.createElement('option');
+                    opt.value = m.name;
+                    opt.textContent = m.name;
+                    select.appendChild(opt);
+                });
+            } catch (err) {
+                console.error('Failed to fetch models', err);
+            }
+        }
+
+        document.getElementById('ollamaUrl').addEventListener('change', fetchModels);
+
+        // Generate Mermaid code using a local LLM via Ollama
+        async function generateWithAI() {
+            const instruction = prompt('Describe the diagram you want:');
+            if (!instruction) return;
+            const url = document.getElementById('ollamaUrl').value;
+            const model = document.getElementById('modelSelect').value;
+            try {
+                const resp = await fetch(url + '/api/generate', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        model,
+                        prompt: `Write only Mermaid code for this diagram:\n${instruction}`,
+                        stream: false
+                    })
+                });
+                const data = await resp.json();
+                if (data && data.response) {
+                    document.getElementById('code').value = data.response.trim();
+                    renderGraph();
+                }
+            } catch (err) {
+                alert('Failed to contact Ollama: ' + err.message);
+            }
+        }
+
+        document.getElementById('aiBtn').addEventListener('click', generateWithAI);
+        // Initial model list
+        fetchModels();
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow generating Mermaid code via a local Ollama LLM
- describe how to use the AI integration in README
- make Ollama server URL and model configurable and list models automatically

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ab01a7fe4832787df91c69a3c6c6e